### PR TITLE
Improves port setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ env:
   global:
     - CONTAINER: web
     - APPLICATION_NAME: nebula
-    - DJANGO_PORT: 8000
+    - APPLICATION_PORT: 8000
 before_install:
   - cp ${APPLICATION_NAME}/config.py.example ${APPLICATION_NAME}/config.py
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker-compose up -d
 # install:
 #   - pip install pre-commit && pre-commit install
-#   - ./wait-for-it.sh $CONTAINER:$DJANGO_PORT -- docker-compose exec $CONTAINER pip install coverage
+#   - ./wait-for-it.sh $CONTAINER:$APPLICATION_PORT -- docker-compose exec $CONTAINER pip install coverage
 # script:
 #   - pre-commit run --all-files --show-diff-on-failure
 #   - docker-compose exec $CONTAINER coverage run manage.py test

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ When you're done, shut down docker-compose:
 - Create a file called `config.py.example` which mirrors the structure of `config.py`. This helps to document which configs are required, and can also be used for automated unit testing.
 - Point your database at the Postgres database running as a separate service.
 - With [pre-commit](https://pre-commit.com/) installed, run `pre-commit install` to add git pre-commit hooks to your CI pipeline.
-- Ensure that the port exposed in `docker-compose.yml` match the port the app is running on in `entrypoint.sh` and the value of the `DJANGO_PORT` variable in `.travis.yml`.
+- Update the default values for the ports exposed in `docker-compose.yml` for local development.
+- Update the value of the `DJANGO_PORT` variable in `.travis.yml` for the deployed application.
 - Update the `CONTAINER`, `APPLICATION_NAME` variables in `.travis.yml` and uncomment out the commented job steps.
 - Add Travis CI environment variables for `DOCKER_USERNAME` and `DOCKER_PASSWORD` in the UI at <https://travis-ci.com>.
 - Before pushing code, remember to change your remotes!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,12 @@ services:
   web:
     build: .
     # entrypoint: /code/entrypoint.sh
+    environment:
+      - APPLICATION_PORT=${APPLICATION_PORT:-8000}
     volumes:
       - .:/code
     ports:
-      - "8000:8000"
+      - "${APPLICATION_PORT:-8000}:${APPLICATION_PORT:-8000}"
     depends_on:
       - db
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ echo "Apply database migrations"
 
 #Start server
 echo "Starting server"
-python manage.py runserver 0.0.0.0:8000
+python manage.py runserver 0.0.0.0:${APPLICATION_PORT}


### PR DESCRIPTION
Simplifies port setting for local development as well as Travis CI.
- Uses an $APPLICATION_PORT variable in Travis CI to set the port on which the application is expected to run. The Docker Compose file will pick up that variable and pass it along to the container, where is is used by entrypoint.sh.
- For local development, this environment variable will not be available, so there are default values in the Docker Compose file, which again are passed along to the container.

To run on a different port locally, you will simply need to change the default values in the Compose file. 
To update the port on which the application is deployed, either change the value in .travis.yml or, if applicable, the value assigned to $APPLICATION_PORT in the Travis settings UI.